### PR TITLE
Bandcamp Friday Accuracy

### DIFF
--- a/generic_parser.py
+++ b/generic_parser.py
@@ -45,6 +45,27 @@ def udpateSsf(links, parserName, user, prefix, newSource = False):
 
     print(f"{prefix} Exited successfully")
 
+def isItBandcampFriday():
+    requestsResponse = requests.get(f"https://isitbandcampfriday.com/", headers={'user-agent': 'Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11'})
+    rawContent = requestsResponse.content
+
+    soup = BeautifulSoup(rawContent, 'html.parser')
+    #yesWord = soup.select('span.next-fundraiser')
+    nextDates = soup.select('div#bandcamp-friday-vm')[0]["data-fundraisers"]
+
+    theNextDate = nextDates[nextDates.index("\"display\":") + 11:nextDates.index("\"},{")]
+
+    theNextDate = theNextDate.replace("th,", "")
+    theNextDate = theNextDate.replace("st,", "")
+    theNextDate = theNextDate.replace("rd,", "")
+    theNextDate = theNextDate.replace("nd,", "")
+    dateOfNextBandcampFriday = datetime.datetime.strptime(theNextDate, '%B %d %Y')
+    dateOfNextBandcampFriday = dateOfNextBandcampFriday + datetime.timedelta(days=-1)
+    today = datetime.datetime.now().date()
+    isItThough = dateOfNextBandcampFriday == datetime.datetime(today.year, today.month, today.day)
+
+    return isItThough
+
 def getLinks(source, prefix, querySelector, urlPostfix):
     requestsResponse = requests.get(f"{source.replace(const._newIndicator, '')}", headers={'user-agent': 'Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11'})
     rawContent = requestsResponse.content

--- a/user_orchestrator.py
+++ b/user_orchestrator.py
@@ -37,7 +37,8 @@ _process = re.compile(r"[^\\\/]+$").search(sys.argv[0]).group(0)
 _prefix = f"[{_process}]:"
 
 # add notification on Thursday (4) so that it will appear Friday morning
-if(datetime.datetime.today().weekday() == 4 and datetime.datetime.today().day <= 7):
+#if(datetime.datetime.today().weekday() == 4 and datetime.datetime.today().day <= 7):
+if(generic_parser.isItBandcampFriday()):
     rss_aggregator.addBandcampFridayItem()
     update = True
 


### PR DESCRIPTION
As it turns out, Bandcamp Friday is not just the 1st Friday of every month. Use the official https://isitbandcampfriday.com/ website to determine if it is _actually_ Bandcamp Friday.

Technical details:
- The majority of the visual indicators on the site are handled via stylesheets and JS, which a default request can't handle because it doesn't run JS
  - Instead, look for a special div that has some data with contains the next date in which it is Bandcamp friday
  - Parse the date, then compare that minus 1 day against today to create the notification for the next day