### PR TITLE
Add Delay to all Requests to Avoid Temporary IP Blocks from Bandcamp (and to be Respectful of thier APIs)

### DIFF
--- a/const.py
+++ b/const.py
@@ -13,3 +13,4 @@ _bandcampFridayGifs = [
     "https://media.discordapp.net/attachments/971520732544766002/1221323444810154004/BandcampFriday2.gif?ex=66122918&is=65ffb418&hm=0c345350097384a5678287b85123659c294aff4baa9b4bc3bd76f8eee09e6a39&=",
     "https://media.discordapp.net/attachments/971520732544766002/1221323445217005668/BandcampFriday3.gif?ex=66122918&is=65ffb418&hm=06b0142b915e51f0e11ad205f99ae2428cdeb5c7631064cd7a0a0359334036a5&="
 ]
+_pingDelay = 0.1

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -1,3 +1,4 @@
+import time
 import datetime
 import requests
 import const
@@ -46,6 +47,7 @@ def udpateSsf(links, parserName, user, prefix, newSource = False):
     print(f"{prefix} Exited successfully")
 
 def isItBandcampFriday():
+    time.sleep(const._pingDelay)
     requestsResponse = requests.get(f"https://isitbandcampfriday.com/", headers={'user-agent': 'Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11'})
     rawContent = requestsResponse.content
 
@@ -67,6 +69,7 @@ def isItBandcampFriday():
     return isItThough
 
 def getLinks(source, prefix, querySelector, urlPostfix):
+    time.sleep(const._pingDelay)
     requestsResponse = requests.get(f"{source.replace(const._newIndicator, '')}", headers={'user-agent': 'Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11'})
     rawContent = requestsResponse.content
 
@@ -123,6 +126,7 @@ def runGet(user, parserName, urlPostfix, querySelector, artists=[]):
 def runPost(user, fanID, parserName, urlPostfix, tokenPostfix, field, subfields):
     process = f"{parserName}_parser.py"
     prefix = f"[{process}:{user}]:"
+    time.sleep(const._pingDelay)
     postResponse = requests.post(f"{const._bandcampCollectionAPI}/{urlPostfix}", f"{{\"fan_id\":{fanID},\"older_than_token\":\"9999999999:9999999999{tokenPostfix}\",\"count\":1000000}}")
     jsondata = postResponse.json()[field]
     links = []


### PR DESCRIPTION
This is an attempt to fix #21, but is also a good feature to have in general