### PR TITLE
Bandcamp Friday Website JSON Parsing Fix

### DIFF
--- a/generic_parser.py
+++ b/generic_parser.py
@@ -4,6 +4,7 @@ import requests
 import const
 from bs4 import BeautifulSoup
 import re
+import json
 
 # links: the array of links output from the calling function; a list of links we want to update on
 # parserName: the parserName from the calling function
@@ -55,14 +56,13 @@ def isItBandcampFriday():
     #yesWord = soup.select('span.next-fundraiser')
     nextDates = soup.select('div#bandcamp-friday-vm')[0]["data-fundraisers"]
 
-    theNextDate = nextDates[nextDates.index("\"display\":") + 11:nextDates.index("\"},{")]
+    theNextDate = json.loads(nextDates)[0]["display"]
 
     theNextDate = theNextDate.replace("th,", "")
     theNextDate = theNextDate.replace("st,", "")
     theNextDate = theNextDate.replace("rd,", "")
     theNextDate = theNextDate.replace("nd,", "")
     dateOfNextBandcampFriday = datetime.datetime.strptime(theNextDate, '%B %d %Y')
-    dateOfNextBandcampFriday = dateOfNextBandcampFriday + datetime.timedelta(days=-1)
     today = datetime.datetime.now().date()
     isItThough = dateOfNextBandcampFriday == datetime.datetime(today.year, today.month, today.day)
 


### PR DESCRIPTION
We were parsing JSON weirdly since we didn't want to add another dependency or something. Not really sure why I did it that way in the first place...

Now we use the `json` library to parse it so we know we are getting the `"display"` property on the `data-fundraisers` attribute.

Additionally, it looks like we are getting Bandcamp Friday notifications 1 day early. Our pervious implementation required setting the notification back 1 day, but apparently this new implementation does not require that. Probably a time-zone issue that I could make sense of but instead we will just offset (or remove offset) until it works.