### PR TITLE
Bandcamp Friday: Continue Updates During Failure; Add Debug Logs

### DIFF
--- a/SSF/wishlist_bsg__.ssf
+++ b/SSF/wishlist_bsg__.ssf
@@ -1,3 +1,4 @@
+2024-03-08 11:47:21.442289
 NEW: https://heavyfeelings.bandcamp.com/album/heavy-feelings-ep
 https://staticagemusik.bandcamp.com/album/aus-der-sch-ne-schein
 https://purityfilter.bandcamp.com/album/imago

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -70,7 +70,7 @@ def isItBandcampFriday():
         return isItThough
     else:
         print("Unable to find next bandcamp Friday. Recieved: " + soup.text)
-        print("Here's the raw HTML: " + rawContent)
+        print("Here's the raw HTML: " + (str)(rawContent))
         return False
 
 def getLinks(source, prefix, querySelector, urlPostfix):

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -54,7 +54,7 @@ def isItBandcampFriday():
 
     soup = BeautifulSoup(rawContent, 'html.parser')
     #yesWord = soup.select('span.next-fundraiser')
-    if(len(soup.select('div#bandcamp-friday-vm')) > 1):
+    if(len(soup.select('div#bandcamp-friday-vm')) > 0):
         nextDates = soup.select('div#bandcamp-friday-vm')[0]["data-fundraisers"]
 
         theNextDate = json.loads(nextDates)[0]["display"]
@@ -68,7 +68,9 @@ def isItBandcampFriday():
         isItThough = dateOfNextBandcampFriday == datetime.datetime(today.year, today.month, today.day)
 
         return isItThough
-    return False
+    else:
+        print("Unable to find next bandcamp Friday. Recieved: " + soup.text)
+        return False
 
 def getLinks(source, prefix, querySelector, urlPostfix):
     time.sleep(const._pingDelay)

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -54,7 +54,7 @@ def isItBandcampFriday():
 
     soup = BeautifulSoup(rawContent, 'html.parser')
     #yesWord = soup.select('span.next-fundraiser')
-    if(len(soup.select('div#bandcamp-friday-vm')) > 0):
+    if(len(soup.select('div#bandcamp-friday-vm')) > 0 and soup.select('div#bandcamp-friday-vm')[0].has_attr("data-fundraisers")):
         nextDates = soup.select('div#bandcamp-friday-vm')[0]["data-fundraisers"]
 
         theNextDate = json.loads(nextDates)[0]["display"]
@@ -70,6 +70,7 @@ def isItBandcampFriday():
         return isItThough
     else:
         print("Unable to find next bandcamp Friday. Recieved: " + soup.text)
+        print("Here's the raw HTML: " + rawContent)
         return False
 
 def getLinks(source, prefix, querySelector, urlPostfix):

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -54,19 +54,21 @@ def isItBandcampFriday():
 
     soup = BeautifulSoup(rawContent, 'html.parser')
     #yesWord = soup.select('span.next-fundraiser')
-    nextDates = soup.select('div#bandcamp-friday-vm')[0]["data-fundraisers"]
+    if(len(soup.select('div#bandcamp-friday-vm')) > 1):
+        nextDates = soup.select('div#bandcamp-friday-vm')[0]["data-fundraisers"]
 
-    theNextDate = json.loads(nextDates)[0]["display"]
+        theNextDate = json.loads(nextDates)[0]["display"]
 
-    theNextDate = theNextDate.replace("th,", "")
-    theNextDate = theNextDate.replace("st,", "")
-    theNextDate = theNextDate.replace("rd,", "")
-    theNextDate = theNextDate.replace("nd,", "")
-    dateOfNextBandcampFriday = datetime.datetime.strptime(theNextDate, '%B %d %Y')
-    today = datetime.datetime.now().date()
-    isItThough = dateOfNextBandcampFriday == datetime.datetime(today.year, today.month, today.day)
+        theNextDate = theNextDate.replace("th,", "")
+        theNextDate = theNextDate.replace("st,", "")
+        theNextDate = theNextDate.replace("rd,", "")
+        theNextDate = theNextDate.replace("nd,", "")
+        dateOfNextBandcampFriday = datetime.datetime.strptime(theNextDate, '%B %d %Y')
+        today = datetime.datetime.now().date()
+        isItThough = dateOfNextBandcampFriday == datetime.datetime(today.year, today.month, today.day)
 
-    return isItThough
+        return isItThough
+    return False
 
 def getLinks(source, prefix, querySelector, urlPostfix):
     time.sleep(const._pingDelay)


### PR DESCRIPTION
The github action runner appears to be getting blocked from accessing the "Is it Bandcamp Friday" website. Locally, we can still access the site and it works as expected, finding the next date (which is actually in the past, implying that there are no future Bandcamp Fridays planned.

For now, make the code "safe" against this kind of issue and print out any information we can use to fix this.