### PR TITLE
Remove Date Cutoff Safety Check

### DIFF
--- a/rss_aggregator.py
+++ b/rss_aggregator.py
@@ -26,11 +26,7 @@ def createItem(titlePrefix, guidPrefix, date, links, user):
 def run(user, parsers):
     _user = user
     _prefix = f"[{_process}:{_user}]:"
-
-    cutoffDate = datetime.datetime.now()
-    cutoffDate = cutoffDate.__add__(datetime.timedelta(seconds=-21600))
     items = []
-
     for parser in parsers:
         ssf = open(f"{const._ssf_path}/{parser}_{_user}.ssf")
         ssfDate = datetime.datetime.fromisoformat((ssf.readline())[0:-1])
@@ -39,7 +35,7 @@ def run(user, parsers):
         for link in ssfLinks:
             if link.startswith(const._newIndicator):
                     newSsfLinks.append(link.replace(const._newIndicator, ""))
-        if ssfDate > cutoffDate and len(newSsfLinks) > 0:
+        if len(newSsfLinks) > 0:
             items.append(createItem(f"{parser.capitalize()} update for ", parser, ssfDate, " ".join(newSsfLinks), _user))
 
     #update RSS file


### PR DESCRIPTION
This "safety" check was preventing us from updating the RSS feed. Remove this check so that any updates appear regardless of what date timestamp we have in the SSF files. That date should only be used for debugging purposes, not behavioral purposes