### PR TITLE
Upcoming Artist Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ This tool creates an RSS feed for the following "actions" that can occur related
   - Only notifies for artists you follow
   - If you follow an artist, all releases on that day will not appear as new.
     - Any releases released after the day of following a new artist will appear
--  Bandcamp Friday Notifications [ :warning: Not consistently working]
+-  Bandcamp Friday Notifications
    - User-independent and based on the official https://isitbandcampfriday.com/ website


### PR DESCRIPTION
TODO
- [ ] Start grabbing artist data and put it in a separate output feed
- [ ] Determine how people can easily filter to the locations they need
  - Idea: make a different feed for each city mentioned on Bandcamp. To get a radius of "nearby concerts" users would need to follow multiple feeds or otherwise find their own way of aggregating
    - Highly granular, aggregation may be difficult, finding all possible locations will be difficult (maybe we could scrape Bandcamp for locations, but there's no guarantee I'll find _all_ of them), nearly infinite number of files possible
  - Idea: put all events into 1 separate feed, and place the burden on users to filter the data to "nearby concerts"
    - More burden on user, easier to implement, harder to filter depending on consumer
    - ⭐ Let's start with this idea, it is the simplest, we can expand later
  - Idea: Group feeds by coordinates on the Earth, allowing users to select a number of coordinates to follow
    - Difficult to implement (would require some kind of geo-location API I can send Bandcamp's location names to), possibly hard for users to understand or use, possible a lot of files, but not infinite, all possible locations are defined
- [ ] Update readme to explain separate feed; update features section

Also, Bandcamp Friday notifications have been proven to be consistent for the last 3 instances, so the readme needs to be updated.