### PR TITLE
Utilize Bandcamp API for all Update Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ images/
 
 # for internal testing, non-production code
 scratch.py
+.vscode/settings.json

--- a/const.py
+++ b/const.py
@@ -6,6 +6,8 @@ _guid = "{{guid}}"
 _ssf_path = "./SSF"
 _newIndicator = "NEW: "
 _bandcampCollectionAPI = "https://bandcamp.com/api/fancollection/1"
+_bandcampReleasesEndpoint = "https://bandcamp.com/api/mobile/24/band_details"
+_bandcampTralbumDetailsEndpoint = "https://bandcamp.com/api/mobile/24/tralbum_details"
 _releasesFolder = "Releases"
 _musicPostfix = "/music"
 _bandcampFridayGifs = [
@@ -13,4 +15,4 @@ _bandcampFridayGifs = [
     "https://media.discordapp.net/attachments/971520732544766002/1221323444810154004/BandcampFriday2.gif?ex=66122918&is=65ffb418&hm=0c345350097384a5678287b85123659c294aff4baa9b4bc3bd76f8eee09e6a39&=",
     "https://media.discordapp.net/attachments/971520732544766002/1221323445217005668/BandcampFriday3.gif?ex=66122918&is=65ffb418&hm=06b0142b915e51f0e11ad205f99ae2428cdeb5c7631064cd7a0a0359334036a5&="
 ]
-_pingDelay = 1
+_pingDelay = 0.1

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -24,7 +24,7 @@ def updateSsf(links, parserName, user, prefix, newIndicatorString):
         existingLinks = ssfAll.splitlines()
 
         for link in links:
-            if(not existingLinks.__contains__(link)):
+            if(not existingLinks.__contains__(str(link))): # str required when comparing string to int
                 newLinks.append(link)
         
         # this is the only trackable object that should handle deletes. The releases for those that were followed will persist when you unfollow
@@ -56,6 +56,38 @@ def updateSsf(links, parserName, user, prefix, newIndicatorString):
     ssfw.close()
 
     print(f"{prefix} Exited successfully")
+
+# returns any data that was not already found in the internal SSF. This is essentially pre-removing all existing data so we can minimize API calls
+def updateInternalSsf(data, fileName, user, prefix):
+    print(f"{prefix} Updating Internal File with {len(data)} items...")
+
+    existingData = []
+    newData = []
+    try:
+        ssfr = open(f"{const._ssf_path}/{fileName}_{user}.ssf", "r", -1, "utf-8")
+        ssfAll = ssfr.read()
+        ssfr.close()
+
+        existingData = ssfAll.splitlines()
+
+        for datum in data:
+            if(not existingData.__contains__(str(datum))):
+                newData.append(datum)
+
+    except:
+        print(f"{prefix} {fileName.capitalize()} SSF for this user DNE, must be a new user.")
+        newData = data #if it didn't exist before, it's all new!
+    
+    print(f"{prefix} Found {len(newData)} new {fileName} items")
+
+    ssfw = open(f"{const._ssf_path}/{fileName}_{user}.ssf", "a", -1, "utf-8")
+    
+    for newDatum in newData:
+        ssfw.write(f"{newDatum}")
+        ssfw.write("\n")
+    ssfw.close()
+
+    return newData
 
 def prependCurrentDateToSsfIfNecessary(parserName, user):
     ssfr = open(f"{const._ssf_path}/{parserName}_{user}.ssf", "r", -1, "utf-8")
@@ -149,7 +181,7 @@ def getLinks(source, prefix, querySelectors, urlPostfix):
 # querySelectors: a list of CSS query selectors that point to a list of links that we want to update on. Will attempt each query in order until at least 1 link is found. Not a union.
 # baseUrl: the start base of the URL for which to find links in. For user collections & following, that's "https://bandcamp.com/{user}/"
 # forceNotNew: Tells the remaining methods to not treat all incoming links as NEW for this URL, used for newly followed artists' releases
-def runGet(user, parserName, urlPostfix, querySelectors, baseUrl, forceNotNew = False):
+def runGetScrape(user, parserName, urlPostfix, querySelectors, baseUrl, forceNotNew = False):
     process = f"{parserName}_parser"
     prefix = f"[{process}:{user}]:"
 
@@ -167,6 +199,62 @@ def runGet(user, parserName, urlPostfix, querySelectors, baseUrl, forceNotNew = 
         updateSsf(links, parserName, user, prefix, "")
     else:
         updateSsf(links, parserName, user, prefix, const._newIndicator)
+
+def runGet(url, field, subfields, prefix):
+    time.sleep(const._pingDelay)
+    jsondata = [] #array just so error handling can check length only
+    getResponse = {}
+    try:
+        getResponse = requests.get(url)
+    except:
+        time.sleep(30)
+        try:
+            getResponse = requests.get(url)
+        except:
+            print(f"{prefix} Could not GET {url}")
+    try:
+        jsondata = getResponse.json()[field]
+    except:
+        wee = 1
+        #print(f"{prefix} (possibly expected) Could not find {field} field in GET {url}")
+    if(len(subfields) > 0):
+        items = []
+        try:
+            for data in jsondata:
+                drilldown = data
+                for subfield in subfields:
+                    drilldown = drilldown[subfield]
+                else:
+                    items.append(drilldown)
+        except:
+            print(f"{prefix} Could not find one or more subfields for {field}")
+        return items
+    else:
+        return jsondata
+
+# user: the username of the bandcamp user we are pinging for
+# fanID: The internal ID bandcamp uses for a specific user, should be placed in users.ssf after each username with a space in between
+# parserName: 1 word, suitable for use in logging and file names, lowercase
+# urlPostfix: The endpoint you want to ping. Known endpoints include: "collection_items", "wishlist_items", "following_bands"
+# tokenPostfix: Some of the bandcamp endpoints require a special postfix on the end of the older_than_token
+# field: the top level field that we will loop through
+# subfields: an array of subfields on the objects we are looping through that leads to the field we want
+# raw: set to true if you want the raw data from whatever subfield you are accessing (i.e. no URL wrap)
+def runGetReleases(user, fanID, parserName, artist_id, field, subfields, newArtist=False):
+    process = f"{parserName}_parser"
+    prefix = f"[{process}:{user}]:"
+    items = runGet(f"{const._bandcampReleasesEndpoint}?band_id={artist_id}", field, subfields, prefix)
+    finalItems = [f"{artist_id}:{x}" for x in items]
+    # newItems = updateInternalSsf(items, "discography_item_ids", user, prefix)
+    # newLinks = []
+    # for newItem in newItems:
+    #     albumLink = runGet(f"{const._bandcampTralbumDetailsEndpoint}?band_id={artist_id}&tralbum_id={newItem}&tralbum_type=a", "bandcamp_url", [], prefix)
+    #     if(len(albumLink) == 0):
+    #         trackLink = runGet(f"{const._bandcampTralbumDetailsEndpoint}?band_id={artist_id}&tralbum_id={newItem}&tralbum_type=t", "bandcamp_url", [], prefix)
+    #         newLinks.append(trackLink)
+    #     else:
+    #         newLinks.append(albumLink)
+    updateSsf(finalItems, parserName, user, prefix, "" if newArtist else const._newIndicator)
 
 # user: the username of the bandcamp user we are pinging for
 # fanID: The internal ID bandcamp uses for a specific user, should be placed in users.ssf after each username with a space in between
@@ -200,8 +288,16 @@ def runPost(user, fanID, parserName, urlPostfix, tokenPostfix, field, subfields)
             links.append(f"https://{drilldown}.bandcamp.com{const._musicPostfix}")
         else:
             links.append(drilldown)
-    
+
     updateSsf(links, parserName, user, prefix, const._newIndicator)
+    
+    if(parserName == "following"):
+        artists = []
+        for data in jsondata:
+            artists.append(data['band_id'])
+        newArtists = updateInternalSsf(artists, "band_ids", user, prefix)
+        # we need to know both the existing artists and the new artists to avoid notifying all tracks when you follow
+        return [[existingArtists for existingArtists in artists if existingArtists not in newArtists], newArtists]
 
 def unNewSsf(parserName, user):
     ssfr = open(f"{const._ssf_path}/{parserName}_{user}.ssf", "r", -1, "utf-8")

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -144,8 +144,7 @@ def runGet(url, field, subfields, prefix):
     try:
         jsondata = getResponse.json()[field]
     except:
-        wee = 1
-        #print(f"{prefix} (possibly expected) Could not find {field} field in GET {url}")
+        print(f"{prefix} (possibly expected) Could not find {field} field in GET {url}")
     if(len(subfields) > 0):
         items = []
         try:

--- a/generic_parser.py
+++ b/generic_parser.py
@@ -3,7 +3,6 @@ import datetime
 import requests
 import const
 from bs4 import BeautifulSoup
-import re
 import json
 
 # links: the array of links output from the calling function; a list of links we want to update on
@@ -128,78 +127,8 @@ def isItBandcampFriday():
         print("Here's the raw HTML: " + (str)(rawContent))
         return False
 
-def getLinks(source, prefix, querySelectors, urlPostfix):
-    time.sleep(const._pingDelay)
-    requestsResponse = requests.get(f"{source.replace(const._newIndicator, '')}", headers={'user-agent': 'Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11'})
-    rawContent = requestsResponse.content
-
-    retry = 1
-    while(len(rawContent) == 0 and retry < 33):
-        if(len(rawContent) == 0):
-            print(f"{prefix} Got {len(rawContent)} bytes of data. Retrying...")
-            time.sleep(retry)
-            retry *= 2
-            requestsResponse = requests.get(f"{source.replace(const._newIndicator, '')}", headers={'user-agent': 'Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11'})
-            rawContent = requestsResponse.content
-        else:
-            print(f"{prefix} Got {len(rawContent)} bytes of data.")
-    
-    if(len(rawContent) == 0):
-        print(f"{prefix} WARNING Got {len(rawContent)} bytes of data and exhausted all retries.")
-
-    soup = BeautifulSoup(rawContent, 'html.parser')
-    # this loop is for the artist "woob" and likely other legacy artists that have a different "music" page than nearly every other artist on bandcamp
-    for querySelector in querySelectors:
-        linkElements = soup.select(querySelector)
-        if(len(linkElements) > 0):
-            break
-
-    if(len(linkElements) == 0):
-        linkElements = soup.select('meta[property="og:url"]')
-        try:
-            return [linkElements[0].attrs["content"]] # the artist has exactly 1 tralbum on bandcamp
-        except:
-            return [] # the artist actually has no tralbums on bandcamp currently
-        
-    links = []
-
-    for link in linkElements:
-        if link.get_attribute_list("href")[0].startswith("/"):
-            sanitizedSource = re.sub(f"{urlPostfix}$", "", source) # only remove from the end
-            sanitizedSource = sanitizedSource.replace(const._newIndicator, "")
-            if sanitizedSource.endswith("/"):
-                sanitizedSource = sanitizedSource[:-1]
-            link = f"{sanitizedSource}{link.get_attribute_list('href')[0]}"
-            links.append(link)
-        else:
-            links.append(link.get_attribute_list("href")[0])
-    return links
-
-# user: the user of a bandcamp page, as dsiplayed in the URL for bandcamp
-# parserName: 1 word, suitable for use in logging and file names, lowercase
-# urlPostfix: the path to the webpage we are trying to scrape, coming after "https://bandcamp.com/{user}/"
-# querySelectors: a list of CSS query selectors that point to a list of links that we want to update on. Will attempt each query in order until at least 1 link is found. Not a union.
-# baseUrl: the start base of the URL for which to find links in. For user collections & following, that's "https://bandcamp.com/{user}/"
-# forceNotNew: Tells the remaining methods to not treat all incoming links as NEW for this URL, used for newly followed artists' releases
-def runGetScrape(user, parserName, urlPostfix, querySelectors, baseUrl, forceNotNew = False):
-    process = f"{parserName}_parser"
-    prefix = f"[{process}:{user}]:"
-
-    print(f"{prefix} Pinging bandcamp {parserName} feed for user {user} [{baseUrl}/{urlPostfix}]")
-
-    links = []
-    links = getLinks(f"{baseUrl}/{urlPostfix}", prefix, querySelectors, urlPostfix)
-
-    if(len(links) == 0):
-        # This is usually because the artist does not have any tralbums on bandcamp yet
-        print(f"{prefix} WARNING - could not find any links for {baseUrl}/{urlPostfix}")
-
-    if(forceNotNew):
-        # When first following an artist, don't display all music as new releases. NOTE: any release that occurs on the same day you follow an artist will not be tracked
-        updateSsf(links, parserName, user, prefix, "")
-    else:
-        updateSsf(links, parserName, user, prefix, const._newIndicator)
-
+# Gets a piece of data (or pieces if you specify a subfield)
+# It gets the JSON value of data at url -> response.field.subfields[0].subfields[1].subfields[2] etc.
 def runGet(url, field, subfields, prefix):
     time.sleep(const._pingDelay)
     jsondata = [] #array just so error handling can check length only
@@ -233,27 +162,15 @@ def runGet(url, field, subfields, prefix):
         return jsondata
 
 # user: the username of the bandcamp user we are pinging for
-# fanID: The internal ID bandcamp uses for a specific user, should be placed in users.ssf after each username with a space in between
-# parserName: 1 word, suitable for use in logging and file names, lowercase
-# urlPostfix: The endpoint you want to ping. Known endpoints include: "collection_items", "wishlist_items", "following_bands"
-# tokenPostfix: Some of the bandcamp endpoints require a special postfix on the end of the older_than_token
 # field: the top level field that we will loop through
 # subfields: an array of subfields on the objects we are looping through that leads to the field we want
-# raw: set to true if you want the raw data from whatever subfield you are accessing (i.e. no URL wrap)
-def runGetReleases(user, fanID, parserName, artist_id, field, subfields, newArtist=False):
+# newArtist: determines if we should aim to notify about this released tralbum if it is new or not
+def runGetReleases(user, artist_id, field, subfields, newArtist=False):
+    parserName = "release"
     process = f"{parserName}_parser"
     prefix = f"[{process}:{user}]:"
     items = runGet(f"{const._bandcampReleasesEndpoint}?band_id={artist_id}", field, subfields, prefix)
     finalItems = [f"{artist_id}:{x}" for x in items]
-    # newItems = updateInternalSsf(items, "discography_item_ids", user, prefix)
-    # newLinks = []
-    # for newItem in newItems:
-    #     albumLink = runGet(f"{const._bandcampTralbumDetailsEndpoint}?band_id={artist_id}&tralbum_id={newItem}&tralbum_type=a", "bandcamp_url", [], prefix)
-    #     if(len(albumLink) == 0):
-    #         trackLink = runGet(f"{const._bandcampTralbumDetailsEndpoint}?band_id={artist_id}&tralbum_id={newItem}&tralbum_type=t", "bandcamp_url", [], prefix)
-    #         newLinks.append(trackLink)
-    #     else:
-    #         newLinks.append(albumLink)
     updateSsf(finalItems, parserName, user, prefix, "" if newArtist else const._newIndicator)
 
 # user: the username of the bandcamp user we are pinging for

--- a/rss_aggregator.py
+++ b/rss_aggregator.py
@@ -1,6 +1,7 @@
 import datetime
 import const
 import random
+import generic_parser
 
 _process = "rss_aggregator.py"
 _user = "unknown user..."
@@ -35,7 +36,21 @@ def run(user, parsers):
             if link.startswith(const._newIndicator):
                     newSsfLinks.append(link.replace(const._newIndicator, ""))
         if len(newSsfLinks) > 0:
-            items.append(createItem(f"{parser.capitalize()} update for ", parser, datetime.datetime.now(), " ".join(newSsfLinks), _user))
+            if(parser == "release"):
+                #since releases are all BC internal item_ids, we need to convert the new ones to links
+                newLinks = []
+                for newItem in newSsfLinks:
+                    artist_id = newItem.split(":")[0]
+                    tralbum_id = newItem.split(":")[1]
+                    albumLink = generic_parser.runGet(f"{const._bandcampTralbumDetailsEndpoint}?band_id={artist_id}&tralbum_id={tralbum_id}&tralbum_type=a", "bandcamp_url", [], _prefix)
+                    if(len(albumLink) == 0):
+                        trackLink = generic_parser.runGet(f"{const._bandcampTralbumDetailsEndpoint}?band_id={artist_id}&tralbum_id={tralbum_id}&tralbum_type=t", "bandcamp_url", [], _prefix)
+                        newLinks.append(trackLink)
+                    else:
+                        newLinks.append(albumLink)
+                items.append(createItem(f"{parser.capitalize()} update for ", parser, datetime.datetime.now(), " ".join(newLinks), _user))
+            else:
+                items.append(createItem(f"{parser.capitalize()} update for ", parser, datetime.datetime.now(), " ".join(newSsfLinks), _user))
 
     #update RSS file
     if len(items) > 0:

--- a/user_orchestrator.py
+++ b/user_orchestrator.py
@@ -77,17 +77,24 @@ for userTuple in users:
     fanId = userTuple[1]
     for type in supportedSSFTypes:
         generic_parser.unNewSsf(type, user)
-    generic_parser.runPost(user, fanId, "following", "following_bands", "", "followeers", ["url_hints", "subdomain"])
+    allArtists = generic_parser.runPost(user, fanId, "following", "following_bands", "", "followeers", ["url_hints", "subdomain"])
+    existingArtists = allArtists[0]
+    newArtists = allArtists[1]
     generic_parser.runPost(user, fanId, "collection", "collection_items", ":p::", "items", ["item_url"])
     generic_parser.runPost(user, fanId, "wishlist", "wishlist_items", ":a::", "items", ["item_url"])
     followFile = open(f"{const._ssf_path}/following_{user}.ssf")
     followFile.readline()
     artists = followFile.read().splitlines()
     followFile.close()
-    for artist in artists:
-        # When you follow an artist, their current releases should NOT show up as new
-        # this alternative query selector is for the artist "woob" and likely other legacy artists that have a different "music" page than nearly every other artist on bandcamp
-        generic_parser.runGet(user, "release", "music", ["ol.music-grid li.music-grid-item a", ".ipCellLabel1 a"], artist[:-len(const._musicPostfix)], artist.startswith(const._newIndicator))
+
+    for artist in existingArtists:
+        generic_parser.runGetReleases(user, fanId, "release", artist, "discography", ["item_id"])
+    for artist in newArtists:
+        generic_parser.runGetReleases(user, fanId, "release", artist, "discography", ["item_id"], True)
+    # for artist in artists:
+    #     # When you follow an artist, their current releases should NOT show up as new
+    #     # this alternative query selector is for the artist "woob" and likely other legacy artists that have a different "music" page than nearly every other artist on bandcamp
+    #     generic_parser.runGetScrape(user, "release", "music", ["ol.music-grid li.music-grid-item a", ".ipCellLabel1 a"], artist[:-len(const._musicPostfix)], artist.startswith(const._newIndicator))
     for type in supportedSSFTypes:
         generic_parser.prependCurrentDateToSsfIfNecessary(type, user)
 

--- a/user_orchestrator.py
+++ b/user_orchestrator.py
@@ -88,13 +88,10 @@ for userTuple in users:
     followFile.close()
 
     for artist in existingArtists:
-        generic_parser.runGetReleases(user, fanId, "release", artist, "discography", ["item_id"])
+        generic_parser.runGetReleases(user, artist, "discography", ["item_id"])
     for artist in newArtists:
-        generic_parser.runGetReleases(user, fanId, "release", artist, "discography", ["item_id"], True)
-    # for artist in artists:
-    #     # When you follow an artist, their current releases should NOT show up as new
-    #     # this alternative query selector is for the artist "woob" and likely other legacy artists that have a different "music" page than nearly every other artist on bandcamp
-    #     generic_parser.runGetScrape(user, "release", "music", ["ol.music-grid li.music-grid-item a", ".ipCellLabel1 a"], artist[:-len(const._musicPostfix)], artist.startswith(const._newIndicator))
+        generic_parser.runGetReleases(user, artist, "discography", ["item_id"], True)
+
     for type in supportedSSFTypes:
         generic_parser.prependCurrentDateToSsfIfNecessary(type, user)
 


### PR DESCRIPTION
⚠️ It's recommended that any forks should manually trigger the action twice in quick succession or disable whatever is reading the RSS feed for 1 run so that it doesn't get spammed with a backlog of updates. In practice, I found ~1000 backlogged released tracks that had not been found by the previous implementation of this RSS feed generator

- [x] Switch the API ONLY
  - The releases SSF now has `{artist_id}:{tralbum_id}` instead of the link to the tralbum
  - This emerges from what Bandcamp returns on their artist discography endpoint, it doesn't include the URL to the tralbum
    - Doing it this way speeds up the initial population of data and reduces the amount of calls we need to make to Bandcamp's API
- [x] Remove any unused scraping code + dependencies
- [x] Any desired/general cleanup

⛔ Blocked by a Client Challenge, we may need to experiment with different headers